### PR TITLE
Remove short tag

### DIFF
--- a/website/include/html_functions.php
+++ b/website/include/html_functions.php
@@ -65,8 +65,7 @@ function error_message()
 <p class="span-10 error">
 	 <?= h($flash['error']) ?>
 </p>
-
-      <?
+      <?php
    }
 }
 


### PR DESCRIPTION
Using PHP 5.6.31 I have an error:
`PHP Parse error:  syntax error, unexpected end of file..`

This is a quick fix for it.
