### PR TITLE
fix MaxRequestWorkers timeout issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,5 @@ COPY current.sql .
 ADD create_mysql_admin_user.sh /create_mysql_admin_user.sh
 ADD php.ini /etc/php5/apache2/php.ini
 ADD php.ini /etc/php5/cli/php.ini
+RUN sed -i 's/150/250/g' /etc/apache2/mods-available/mpm_worker.conf
 RUN chmod 755 /*.sh
-
-
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ ADD create_mysql_admin_user.sh /create_mysql_admin_user.sh
 ADD php.ini /etc/php5/apache2/php.ini
 ADD php.ini /etc/php5/cli/php.ini
 RUN sed -i 's/150/250/g' /etc/apache2/mods-available/mpm_worker.conf
+RUN sed -i 's/150/250/g' /etc/apache2/mods-available/mpm_prefork.conf
 RUN chmod 755 /*.sh


### PR DESCRIPTION
Hello
I sometimes ran into an issue with the Docker container where WackoPicko would just hang itself up when scanning it with an automated tool like arachni, w3af or zap. The apache error log contained the following entry: 
`AH00161: server reached MaxRequestWorkers setting, consider raising the MaxRequestWorkers setting`
So that's exactly what I did to fix the issue. I raised the MaxRequestWorkers setting from 150 to 250 and the issue went away.